### PR TITLE
(fix) Increase PVC storage to 3 GiB

### DIFF
--- a/experimental/deploy/openshift-deployment.yaml
+++ b/experimental/deploy/openshift-deployment.yaml
@@ -8,7 +8,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 2Gi
+      storage: 3Gi
   storageClassName: <my-storage-class>
   volumeName: <volume-name>
 ---


### PR DESCRIPTION
The selected model requires at least 2.13 GiB. With the current configuration model download never finishes.